### PR TITLE
Improve drift correction tool

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text eol=lf
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # ColDriftCorr
+
+ColDriftCorr は Napari 上で画像スタックのドリフト補正を行うための GUI ツールです。PyQt5 を用いた操作パネルからポイントの移動や補正結果の保存が可能です。
+
+## 必要なパッケージ
+- numpy
+- pandas
+- scikit-image
+- PyQt5
+- napari
+- scipy
+
+## 使い方
+1. 必要な依存ライブラリをインストールします：
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. スクリプトを実行して GUI を起動します：
+   ```bash
+   python napari_drift_20250514_02.py
+   ```
+
+## ライセンス
+このプロジェクトは MIT ライセンスの下で公開されています。
+

--- a/napari_drift_20250514_02.py
+++ b/napari_drift_20250514_02.py
@@ -9,7 +9,6 @@ from PyQt5.QtWidgets import (
 from napari import Viewer
 from napari._qt.qt_viewer import QtViewer
 from scipy.optimize import curve_fit
-from contextlib import contextmanager
 
 
 class DualViewerWindow(QWidget):
@@ -78,8 +77,6 @@ class DualViewerWindow(QWidget):
         toggle_btn.clicked.connect(self.toggle_interpolated_visibility)
         control_layout.addWidget(toggle_btn)
 
-        control_panel.setLayout(control_layout)
-        layout.addWidget(control_panel)
 
         start_end_layout = QHBoxLayout()
         self.spin_start = QSpinBox()
@@ -176,7 +173,7 @@ class DualViewerWindow(QWidget):
         save_btn2.clicked.connect(self.save_refined_stack)
         save_layout.addWidget(save_btn2)
         control_layout.addLayout(save_layout)
-        
+
         control_panel.setLayout(control_layout)
         layout.addWidget(control_panel)
 
@@ -237,8 +234,6 @@ class DualViewerWindow(QWidget):
             print(f"✅ Saved Gaussian corrected stack to: {path}")
 
 
-        control_panel.setLayout(control_layout)
-        layout.addWidget(control_panel)
 
     def toggle_coarse(self, checked):
         self.coarse = checked
@@ -480,7 +475,8 @@ class DualViewerWindow(QWidget):
 
 
 
-app = QApplication(sys.argv)
-window = DualViewerWindow()
-window.show()
-app.exec_()
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    window = DualViewerWindow()
+    window.show()
+    app.exec_()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy
+pandas
+scikit-image
+PyQt5
+napari
+scipy


### PR DESCRIPTION
## Summary
- clean up duplicate widget setup and stray layout calls
- remove unused imports and add main guard
- normalize line endings with .gitattributes
- document usage and dependencies in README
- add requirements.txt and MIT LICENSE

## Testing
- `python -m py_compile napari_drift_20250514_02.py`

------
https://chatgpt.com/codex/tasks/task_e_6853c35661c883289047029ad912fae3