### PR TITLE
Fix shape of empty points arrays

### DIFF
--- a/napari_drift_20250514_02.py
+++ b/napari_drift_20250514_02.py
@@ -195,7 +195,9 @@ class DualViewerWindow(QWidget):
             return
 
         points = self.point_layer.data.copy()
-        filtered_points = np.array([p for p in points if not (start <= int(p[0]) <= end)])
+        filtered_points = np.array([
+            p for p in points if not (start <= int(p[0]) <= end)
+        ]).reshape(-1, 3)
         self.point_layer.data = filtered_points
 
     def export_csv_tentative(self):
@@ -277,7 +279,9 @@ class DualViewerWindow(QWidget):
     
         # 実処理用補間 + 補間点をinterpolatedレイヤーに表示
         interp_points = self.interpolate_points_only_for_processing(raw_points)
-        self.interp_layer.data = np.array([p for p in interp_points if p.tolist() not in raw_points.tolist()])
+        self.interp_layer.data = np.array([
+            p for p in interp_points if p.tolist() not in raw_points.tolist()
+        ]).reshape(-1, 3)
     
         images = self.get_input_images()
         if images is None or images.ndim != 3:


### PR DESCRIPTION
## Summary
- avoid IndexError in empty range deletions
- ensure empty interpolated layer data has correct shape

## Testing
- `python -m py_compile napari_drift_20250514_02.py`


------
https://chatgpt.com/codex/tasks/task_e_6853e02b66d483289769fee2b2ce2100